### PR TITLE
fix: repository name in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vite TWA Boilerplate
+# Vue TWA Boilerplate
 
 A boilerplate for building Telegram Web Applications (TWAs) using Telegram Web
 API with the latest technologies like TypeScript, Vite, Vue, ESLint, Prettier,


### PR DESCRIPTION
Rename
**Vite** TWA Bolerplate
into
**Vue** TWA Boilerplate

Fixes 2