### PR TITLE
feat: add repository common definition

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "importSorter.generalConfiguration.sortOnBeforeSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": "always"

--- a/src/@clean/core/domain/common/Entity.test.ts
+++ b/src/@clean/core/domain/common/Entity.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { Entity } from './Entity'
-import { UniqueEntityID } from './UniqueEntityID'
+import UniqueEntityID from './UniqueEntityID'
 
 class TestEntity extends Entity<{ value: string; }> {
   // abstract constructor is hidden by no-useless-constructor definition

--- a/src/@clean/core/domain/common/Entity.ts
+++ b/src/@clean/core/domain/common/Entity.ts
@@ -1,4 +1,4 @@
-import { UniqueEntityID } from './UniqueEntityID'
+import UniqueEntityID from './UniqueEntityID'
 
 const isEntity = (v: any): v is Entity<any> => {
   return v instanceof Entity

--- a/src/@clean/core/domain/common/MutableRepository.ts
+++ b/src/@clean/core/domain/common/MutableRepository.ts
@@ -1,0 +1,8 @@
+import type RepositoryEntity from './RepositoryEntity'
+import type UniqueEntityID from './UniqueEntityID'
+
+export default interface MutableRepository<TEntity extends RepositoryEntity> {
+  addItem(item: TEntity): void
+  addOrUpdateItem(item: TEntity): void
+  removeItem(id: UniqueEntityID): void
+}

--- a/src/@clean/core/domain/common/ReadonlyRepository.ts
+++ b/src/@clean/core/domain/common/ReadonlyRepository.ts
@@ -1,0 +1,9 @@
+import type RepositoryEntity from './RepositoryEntity'
+import type UniqueEntityID from './UniqueEntityID'
+
+export default interface ReadonlyRepository<TEntity extends RepositoryEntity> {
+  readonly length: number
+  getItems(predicate?: (entity: TEntity) => boolean): TEntity[]
+  getById(id: UniqueEntityID): TEntity | undefined
+  exists(id: UniqueEntityID): boolean
+}

--- a/src/@clean/core/domain/common/Repository.ts
+++ b/src/@clean/core/domain/common/Repository.ts
@@ -1,0 +1,6 @@
+import type RepositoryEntity from './RepositoryEntity'
+import type ReadonlyRepository from './ReadonlyRepository'
+import type MutableRepository from './MutableRepository'
+
+export default interface Repository<TEntity extends RepositoryEntity>
+  extends ReadonlyRepository<TEntity>, MutableRepository<TEntity> {}

--- a/src/@clean/core/domain/common/RepositoryEntity.ts
+++ b/src/@clean/core/domain/common/RepositoryEntity.ts
@@ -1,0 +1,5 @@
+import type UniqueEntityID from './UniqueEntityID'
+
+export default interface RepositoryEntity {
+  readonly id: UniqueEntityID
+}

--- a/src/@clean/core/domain/common/UniqueEntityID.ts
+++ b/src/@clean/core/domain/common/UniqueEntityID.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { Identifier } from './Identifier'
 
-export class UniqueEntityID extends Identifier<string | number> {
+export default class UniqueEntityID extends Identifier<string | number> {
   constructor(id?: string | number) {
     super(id ?? uuidv4())
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+
 import App from './App.vue'
 
 createApp(App).mount('#app')


### PR DESCRIPTION
Add common repository definitions.
This update introduces two types of repositories:
- `ReadonlyRepository`
- `Repository` (which combines `ReadonlyRepository` and `MutableRepository`)

Additionally, it resolves an issue where an extra semicolon was automatically inserted after saving.

Closes #5, fixes #6.