### PR TITLE
Create abstract class ValueObject as a common entity

### DIFF
--- a/src/@clean/core/domain/common/ValueObject.test.ts
+++ b/src/@clean/core/domain/common/ValueObject.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import { ValueObject } from '../common/ValueObject'
+
+interface TestProps {
+  a: number
+  b: string
+}
+
+class TestValueObject extends ValueObject<TestProps> {}
+
+describe('ValueObject', () => {
+  it('should be equal to another object with similar properties', () => {
+    const vo1 = new TestValueObject({
+      a: 1,
+      b: 'test'
+    })
+    const vo2 = new TestValueObject({
+      a: 1,
+      b: 'test'
+    })
+    expect(vo1.equals(vo2)).toBe(true)
+  })
+
+  it('should not be equal to an object with different properties', () => {
+    const vo1 = new TestValueObject({
+      a: 1,
+      b: 'test'
+    })
+    const vo2 = new TestValueObject({
+      a: 2,
+      b: 'test'
+    })
+    expect(vo1.equals(vo2)).toBe(false)
+  })
+
+  it('should not be equal to an object with missing properties', () => {
+    const vo1 = new TestValueObject({
+      a: 1,
+      b: 'test'
+    })
+    const vo2 = new TestValueObject({
+      a: 1
+    } as TestProps)
+    expect(vo1.equals(vo2)).toBe(false)
+  })
+
+  it('should return false if null is passed', () => {
+    const vo = new TestValueObject({
+      a: 1,
+      b: 'test'
+    })
+    // @ts-expect-error: null is a purposely incorrect test argument
+    expect(vo.equals(null)).toBe(false)
+  })
+
+  it('should return false if undefined is passed', () => {
+    const vo = new TestValueObject({
+      a: 1,
+      b: 'test'
+    })
+    expect(vo.equals(undefined)).toBe(false)
+  })
+
+  it('should return false if compared with an object without props', () => {
+    const vo = new TestValueObject({
+      a: 1,
+      b: 'test'
+    })
+    const invalidObject = {
+      notProps: 'value'
+    } // Object without 'props'
+    expect(vo.equals(invalidObject as any)).toBe(false)
+  })
+
+  it('object properties should be immutable', () => {
+    const vo = new TestValueObject({
+      a: 1,
+      b: 'test'
+    })
+    expect(() => {
+      (vo.props as any).a = 2
+    }).toThrow(TypeError)
+  })
+})

--- a/src/@clean/core/domain/common/ValueObject.ts
+++ b/src/@clean/core/domain/common/ValueObject.ts
@@ -1,0 +1,23 @@
+import { shallowEqual } from '@clean/core/libs/ShallowEqual'
+
+interface ValueObjectProps {
+  [index: string]: any
+}
+
+export abstract class ValueObject<T extends ValueObjectProps> {
+  public readonly props: T
+
+  constructor (props: T) {
+    this.props = Object.freeze(props)
+  }
+
+  public equals (vo?: ValueObject<T>): boolean {
+    if (vo === null || vo === undefined) {
+      return false
+    }
+    if (vo.props === undefined) {
+      return false
+    }
+    return shallowEqual(this.props, vo.props)
+  }
+}


### PR DESCRIPTION
An abstract class named ValueObject needs to be created to serve as a common entity for all value objects in the project. This class will encapsulate common functionalities and properties that all value objects should inherit. The implementation should ensure that the value objects adhere to the principles of value equality.

**Tasks:**

- [x] Define the structure and properties of the ValueObject class.
- [x] Implement methods for equality comparison and other common functionalities.
- [x] Ensure the class is abstract, preventing direct instantiation.

Resolves #19 