### PR TITLE
feat(domain): implement specification pattern with composite rules

### DIFF
--- a/src/@clean/core/domain/common/specifications/README.md
+++ b/src/@clean/core/domain/common/specifications/README.md
@@ -1,0 +1,120 @@
+# Specification Pattern
+
+The Specification Pattern allows you to create complex business rules by
+composing simple ones. This implementation provides a flexible and type-safe way
+to build and combine business rules.
+
+## Structure
+
+The pattern is implemented with the following components:
+
+```typescript
+// Base interface
+interface ISpecification<T> {
+  isSatisfiedBy(candidate: T): boolean;
+  and(other: ISpecification<T>): ISpecification<T>;
+  or(other: ISpecification<T>): ISpecification<T>;
+  not(): ISpecification<T>;
+}
+
+// Base abstract class
+abstract class Specification<T> implements ISpecification<T> {
+  protected abstract expression: Expression<T>;
+
+  public isSatisfiedBy(candidate: T): boolean {
+    return this.expression(candidate);
+  }
+  // Implementation of and, or, not methods using SpecificationFactory
+}
+```
+
+## Components
+
+1. **Base Components**:
+
+   - `ISpecification<T>` - Base interface defining specification contract
+   - `Specification<T>` - Abstract base class implementing the interface
+   - `Expression<T>` - Type definition for specification predicates
+
+2. **Composite Specifications**:
+
+   - `AndSpecification<T>` - Combines two specifications with AND logic
+   - `OrSpecification<T>` - Combines two specifications with OR logic
+   - `NotSpecification<T>` - Negates a specification
+
+3. **Factory**:
+   - `SpecificationFactory` - Creates composite specifications avoiding circular
+     dependencies
+
+## Usage Example
+
+```typescript
+// 1. Define your domain type
+interface Product {
+  price: number;
+  inStock: boolean;
+}
+
+// 2. Create concrete specifications
+class PriceSpecification extends Specification<Product> {
+  protected expression: Expression<Product>;
+
+  constructor(private readonly maxPrice: number) {
+    super();
+    this.expression = (product: Product): boolean => {
+      return product.price <= this.maxPrice;
+    };
+  }
+}
+
+class InStockSpecification extends Specification<Product> {
+  protected expression: Expression<Product>;
+
+  constructor() {
+    super();
+    this.expression = (product: Product): boolean => {
+      return product.inStock;
+    };
+  }
+}
+
+// 3. Use specifications
+const maxPrice = new PriceSpecification(100);
+const inStock = new InStockSpecification();
+
+// Using chain methods (recommended)
+const canBePurchased = maxPrice.and(inStock);
+
+// Or using factory directly
+const canBePurchased = SpecificationFactory.and(maxPrice, inStock);
+
+// 4. Apply specifications
+const product = { price: 50, inStock: true };
+if (canBePurchased.isSatisfiedBy(product)) {
+  // Process purchase
+}
+```
+
+## Complex Rules
+
+You can create complex business rules by combining specifications:
+
+```typescript
+const complexRule = maxPrice.and(inStock).or(specialOffer.and(preOrder)).not();
+```
+
+## Best Practices
+
+1. Keep specifications focused on single business rule
+2. Use meaningful names for specifications
+3. Prefer composition over inheritance for complex rules
+4. Use the factory methods when dealing with circular dependencies
+5. Keep the expression logic simple and pure (no side effects)
+
+## Benefits
+
+- Type-safe business rule composition
+- Reusable business logic
+- Single Responsibility Principle compliance
+- Easy to test individual rules
+- Flexible combination of rules

--- a/src/@clean/core/domain/common/specifications/SpecificationFactory.ts
+++ b/src/@clean/core/domain/common/specifications/SpecificationFactory.ts
@@ -1,0 +1,18 @@
+import type { ISpecification } from './base/ISpecification'
+import { AndSpecification } from './composite/AndSpecification'
+import { NotSpecification } from './composite/NotSpecification'
+import { OrSpecification } from './composite/OrSpecification'
+
+export class SpecificationFactory {
+  static and<T>(left: ISpecification<T>, right: ISpecification<T>): ISpecification<T> {
+    return new AndSpecification<T>(left, right)
+  }
+
+  static or<T>(left: ISpecification<T>, right: ISpecification<T>): ISpecification<T> {
+    return new OrSpecification<T>(left, right)
+  }
+
+  static not<T>(specification: ISpecification<T>): ISpecification<T> {
+    return new NotSpecification<T>(specification)
+  }
+}

--- a/src/@clean/core/domain/common/specifications/base/Expression.d.ts
+++ b/src/@clean/core/domain/common/specifications/base/Expression.d.ts
@@ -1,0 +1,1 @@
+export type Expression<T> = (candidate: T) => boolean

--- a/src/@clean/core/domain/common/specifications/base/ISpecification.ts
+++ b/src/@clean/core/domain/common/specifications/base/ISpecification.ts
@@ -1,0 +1,11 @@
+/**
+ * Interface for the Specification pattern that enables composable business
+ * rules
+ * @template T - The type of object that the specification can check
+ */
+export interface ISpecification<T> {
+  isSatisfiedBy(candidate: T): boolean
+  and(other: ISpecification<T>): ISpecification<T>
+  or(other: ISpecification<T>): ISpecification<T>
+  not(): ISpecification<T>
+}

--- a/src/@clean/core/domain/common/specifications/base/Specification.test.ts
+++ b/src/@clean/core/domain/common/specifications/base/Specification.test.ts
@@ -1,0 +1,143 @@
+import { SpecificationFactory } from '../SpecificationFactory'
+import { Specification } from './Specification'
+
+import type { Expression } from './Expression'
+
+// Test interface and implementations
+interface TestProduct {
+  price: number
+  inStock: boolean
+}
+
+class PriceSpecification extends Specification<TestProduct> {
+  protected expression: Expression<TestProduct>
+
+  constructor(private readonly maxPrice: number) {
+    super()
+    this.expression = (product: TestProduct): boolean => {
+      return product.price <= this.maxPrice
+    }
+  }
+}
+
+class InStockSpecification extends Specification<TestProduct> {
+  protected expression: Expression<TestProduct>
+
+  constructor() {
+    super()
+    this.expression = (product: TestProduct): boolean => {
+      return product.inStock
+    }
+  }
+}
+
+describe('Specification', () => {
+  const product1 = {
+    price: 100,
+    inStock: true
+  }
+  const product2 = {
+    price: 200,
+    inStock: false
+  }
+  const product3 = {
+    price: 150,
+    inStock: true
+  }
+
+  describe('isSatisfiedBy', () => {
+    it('should return true when expression is satisfied', () => {
+      const priceSpec = new PriceSpecification(150)
+      expect(priceSpec.isSatisfiedBy(product1)).toBe(true)
+      expect(priceSpec.isSatisfiedBy(product2)).toBe(false)
+    })
+  })
+
+  // Новые тесты для методов базового класса
+  describe('base class methods', () => {
+    let priceSpec: PriceSpecification
+    let stockSpec: InStockSpecification
+
+    beforeEach(() => {
+      priceSpec = new PriceSpecification(150)
+      stockSpec = new InStockSpecification()
+    })
+
+    describe('and', () => {
+      it('should use SpecificationFactory.and for combining specifications', () => {
+        const spy = vi.spyOn(SpecificationFactory, 'and')
+        priceSpec.and(stockSpec)
+
+        expect(spy).toHaveBeenCalledWith(priceSpec, stockSpec)
+        spy.mockRestore()
+      })
+
+      it('should return correct result when chaining and', () => {
+        const combinedSpec = priceSpec.and(stockSpec)
+
+        expect(combinedSpec.isSatisfiedBy(product1)).toBe(true) // price <= 150 && inStock
+        expect(combinedSpec.isSatisfiedBy(product2)).toBe(false) // price > 150 && !inStock
+        expect(combinedSpec.isSatisfiedBy(product3)).toBe(true) // price <= 150 && inStock
+      })
+    })
+
+    describe('or', () => {
+      it('should use SpecificationFactory.or for combining specifications', () => {
+        const spy = vi.spyOn(SpecificationFactory, 'or')
+        priceSpec.or(stockSpec)
+
+        expect(spy).toHaveBeenCalledWith(priceSpec, stockSpec)
+        spy.mockRestore()
+      })
+
+      it('should return correct result when chaining or', () => {
+        const combinedSpec = priceSpec.or(stockSpec)
+
+        expect(combinedSpec.isSatisfiedBy(product1)).toBe(true) // price <= 150 || inStock
+        expect(combinedSpec.isSatisfiedBy(product2)).toBe(false) // price > 150 || !inStock
+        expect(combinedSpec.isSatisfiedBy(product3)).toBe(true) // price <= 150 || inStock
+      })
+    })
+
+    describe('not', () => {
+      it('should use SpecificationFactory.not for negating specification', () => {
+        const spy = vi.spyOn(SpecificationFactory, 'not')
+        priceSpec.not()
+
+        expect(spy).toHaveBeenCalledWith(priceSpec)
+        spy.mockRestore()
+      })
+
+      it('should return correct result when using not', () => {
+        const notSpec = priceSpec.not()
+
+        expect(notSpec.isSatisfiedBy(product1)).toBe(false) // !(price <= 150)
+        expect(notSpec.isSatisfiedBy(product2)).toBe(true) // !(price <= 150)
+        expect(notSpec.isSatisfiedBy(product3)).toBe(false) // !(price <= 150)
+      })
+    })
+
+    // Тест для проверки сложных цепочек методов
+    describe('method chaining', () => {
+      it('should support complex chaining of specifications', () => {
+
+        /**
+         * Test: Имплементация тестовой бизнес логики
+         * sql: (price <= maxPrice AND inStock) OR (NOT inStock)
+         *
+         * Такая комбинация может быть полезна, например, когда нужно показать
+         * товары, которые:
+         * - Можно купить прямо сейчас (подходят по цене и есть в наличии)
+         * - Или можно предзаказать (нет в наличии)
+         */
+        const complexSpec = priceSpec
+          .and(stockSpec)
+          .or(stockSpec.not())
+
+        expect(complexSpec.isSatisfiedBy(product1)).toBe(true) // (price <= 150 && inStock) || !inStock
+        expect(complexSpec.isSatisfiedBy(product2)).toBe(true) // (false && false) || true
+        expect(complexSpec.isSatisfiedBy(product3)).toBe(true) // (true && true) || false
+      })
+    })
+  })
+})

--- a/src/@clean/core/domain/common/specifications/base/Specification.ts
+++ b/src/@clean/core/domain/common/specifications/base/Specification.ts
@@ -1,0 +1,23 @@
+import type { Expression } from './Expression'
+import type { ISpecification } from './ISpecification'
+import { SpecificationFactory } from '../SpecificationFactory'
+
+export abstract class Specification<T> implements ISpecification<T> {
+  protected abstract expression: Expression<T>
+
+  public isSatisfiedBy(candidate: T): boolean {
+    return this.expression(candidate)
+  }
+
+  public and(other: ISpecification<T>): ISpecification<T> {
+    return SpecificationFactory.and(this, other)
+  }
+
+  public or(other: ISpecification<T>): ISpecification<T> {
+    return SpecificationFactory.or(this, other)
+  }
+
+  public not(): ISpecification<T> {
+    return SpecificationFactory.not(this)
+  }
+}

--- a/src/@clean/core/domain/common/specifications/composite/AndSpecification.ts
+++ b/src/@clean/core/domain/common/specifications/composite/AndSpecification.ts
@@ -1,0 +1,16 @@
+import type { Expression } from '../base/Expression'
+import type { ISpecification } from '../base/ISpecification'
+import { Specification } from '../base/Specification'
+
+export class AndSpecification<T> extends Specification<T> {
+  protected expression: Expression<T>
+
+  constructor(
+    private readonly left: ISpecification<T>,
+    private readonly right: ISpecification<T>
+  ) {
+    super()
+    this.expression = (candidate: T): boolean =>
+      this.left.isSatisfiedBy(candidate) && this.right.isSatisfiedBy(candidate)
+  }
+}

--- a/src/@clean/core/domain/common/specifications/composite/NotSpecification.ts
+++ b/src/@clean/core/domain/common/specifications/composite/NotSpecification.ts
@@ -1,0 +1,17 @@
+import type { Expression } from '../base/Expression'
+import type { ISpecification } from '../base/ISpecification'
+import { Specification } from '../base/Specification'
+
+/**
+ * Composite specification that negates another specification
+ * @template T - The type of object that the specification can check
+ */
+export class NotSpecification<T> extends Specification<T> {
+  protected expression: Expression<T>
+
+  constructor(private readonly specification: ISpecification<T>) {
+    super()
+    this.expression = (candidate: T): boolean =>
+      !this.specification.isSatisfiedBy(candidate)
+  }
+}

--- a/src/@clean/core/domain/common/specifications/composite/OrSpecification.ts
+++ b/src/@clean/core/domain/common/specifications/composite/OrSpecification.ts
@@ -1,0 +1,20 @@
+import type { Expression } from '../base/Expression'
+import type { ISpecification } from '../base/ISpecification'
+import { Specification } from '../base/Specification'
+
+/**
+ * Composite specification that combines two specifications with logical OR
+ * @template T - The type of object that the specification can check
+ */
+export class OrSpecification<T> extends Specification<T> {
+  protected expression: Expression<T>
+
+  constructor(
+    private readonly left: ISpecification<T>,
+    private readonly right: ISpecification<T>
+  ) {
+    super()
+    this.expression = (candidate: T): boolean =>
+      this.left.isSatisfiedBy(candidate) || this.right.isSatisfiedBy(candidate)
+  }
+}


### PR DESCRIPTION
This commit introduces the Specification pattern to enable flexible business rule composition in the domain layer.

**Key components include:**

- Base specification classes (interface, abstract class, expression type)
- Composite specifications (And, Or, Not)
- Factory to prevent circular dependencies
- Unit tests and documentation
- Type-safe implementation with TypeScript

Closes #29